### PR TITLE
setting swipeToTriggerTrailingEdge to be true by default

### DIFF
--- a/Sources/SwipeActions.swift
+++ b/Sources/SwipeActions.swift
@@ -374,7 +374,7 @@ public struct SwipeView<Label, LeadingActions, TrailingActions>: View where Labe
     @State var swipeToTriggerLeadingEdge = false
 
     /// Enable triggering the trailing edge via a drag.
-    @State var swipeToTriggerTrailingEdge = false
+    @State var swipeToTriggerTrailingEdge = true
 
     // MARK: - Gesture state
 


### PR DESCRIPTION
In order to fix a bug where swipe actions are not triggered after loading more data settings swipeToTriggerTrailingEdge to true by default.  