### PR TITLE
Fixed an issue with ScrollGesture on SwipeView; Improved swipeDelete Transition by adding Move to Leading transition

### DIFF
--- a/Sources/SwipeActions.swift
+++ b/Sources/SwipeActions.swift
@@ -1282,6 +1282,7 @@ public extension AnyTransition {
             active: SwipeDeleteModifier(visibility: 0),
             identity: SwipeDeleteModifier(visibility: 1)
         )
+        .combined(with: .move(edge: .leading))
     }
 }
 


### PR DESCRIPTION
This mimics the behavior of the iOS swipe to delete action even more accurately, since it slides away in the direction of the swipe when deleting.